### PR TITLE
Correct seek command when writing DFS track

### DIFF
--- a/src/xfer.bas
+++ b/src/xfer.bas
@@ -876,7 +876,7 @@
  8420\ Seek track
  8430LDA #1
  8440STA pblock%+5
- 8450LDA #&29
+ 8450LDA #&69
  8460STA pblock%+6
  8470LDX #pblock% MOD 256
  8480LDY #pblock% DIV 256


### PR DESCRIPTION
Command #&29 doesn't exist for OSWORD &7F, should be #&69 (seek)